### PR TITLE
Number of Floyds

### DIFF
--- a/Config.pde
+++ b/Config.pde
@@ -194,7 +194,7 @@ class Config {
 
             // FLOYD SETTINGS
           } else if (key.equals("floydsRange") && !initialLoadDone) {
-            floydsRange = constrainInts(parseIntRange(value), 1, 9999);
+            floydsRange = constrainInts(parseIntRange(value), 1, 999);
             printToConsole("--> Floyds range set to: " + java.util.Arrays.toString(floydsRange));
           } else if (key.equals("activateFloydRate")) {
             activateFloydRate = constrain(Float.parseFloat(value), 1, 999);

--- a/Visualization.pde
+++ b/Visualization.pde
@@ -17,9 +17,13 @@ class Visualization {
     this.config = config;
     floyds = new Floyd[config.floydsRange[1]];
 
-    // Initialize all Floyds as inactive
+    // Initialize all Floyds, set min number active
+    int floydsToActivate = config.floydsRange[0];
     for (int i = 0; i < floyds.length; i++) {
       floyds[i] = new Floyd(config);
+      if (floydsToActivate-- > 0) {  // need to activate more
+        floyds[i].active = true;
+      }      
     }
 
     masterFloyd = new MasterFloyd(config);

--- a/data/PARAMETERS.ini
+++ b/data/PARAMETERS.ini
@@ -15,7 +15,7 @@ frameRate = 60                                    ; Frame rate for the visualiza
 resolution = 2560, 1440                           ; Window resolution (width 100~5120, height 100~2880) [§]
 windowPosition = 0, 0                             ; Window position from top-left corner (width 0-5120, height 0~2880) [§]
 fullScreen = 0                                    ; Full screen mode (0 or 1) [§]
-debugBins = 1                                     ; Debug display, showing FFT bins and mapped parameters (0 or 1)
+debugBins = 0                                     ; Debug display, showing FFT bins and mapped parameters (0 or 1)
 debugConsole = 1                                  ; Debug console, showing parameter updates (0 or 1) [§]
 recordVideo = 0                                   ; Enables video recording with FFmpeg (0 or 1) [§]
 videoQuality = 90                                 ; Video quality, higher is better (0~100), remapped to -crf (48~1) [§]
@@ -23,7 +23,7 @@ abortAfterFrames = 0                              ; Number of frames to export (
 randomSeedValue = 0                               ; Random seed value for reproducibility (>0 to enable) --> not working properly!
 
 ; ============ FLOYD SETTINGS ============
-floydsRange = 1, 120                              ; Range for the number of Floyds (min, max, 1~9999) [§]
+floydsRange = 1, 120                              ; Range for the number of Floyds (min, max, 1~999) [§]
 activateFloydRate = 3                             ; Total frames between (de)activating one Floyd (1~999)
 velocityRange = 1, 35                             ; Range of Floyd velocity values (min, max, 0~999)
 angleRandomRange = 0.1, 3                         ; Range of angle randomness for Floyds (min, max, 0~100)
@@ -51,7 +51,7 @@ circleHue2 = 180                                  ; Initial hue for second circl
 hueRotationRate = 0.3                             ; Rate at which hue changes per frame (0~100)
 circleSaturationRange = 0.9, 1                    ; Saturation for all circles (min, max, 0~1)
 circleBrightnessRange = 0.2, 1                    ; Intensity range for circle brightness (min, max, 0~1)
-fadeOpacityRange = 15, 15                          ; Opacity range for fading effect (min, max, 0~255)
+fadeOpacityRange = 15, 5                          ; Opacity range for fading effect (min, max, 0~255)
 
 ; ============ DIRECTION AND MOVEMENT BIAS ============
 switchDirectionChanceRange = 0.1, 6               ; Time range (in sec) for direction bias switch interval (min, max, 0~999)


### PR DESCRIPTION
- Changed max number of Floyds (floydsRange) from 9999 to 999; while is is possible to export videos with extreme numbers of Floyds at a constant frame rate, my media player could not decode them without significant frame rate drops.

- Number of Floyds now starts at min number (floydsRange[0]), not necessarily 1.